### PR TITLE
improved #92 SlackRealTimeMessagingAPI 対応

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'org.yaml:snakeyaml:1.15'
     compile 'com.github.masahitojp:nineteen:0.0.3'
-    compile 'com.github.masahitojp:botan-core:0.0.1.3'
+    compile 'com.github.masahitojp:botan-core:0.1.1.+'
     compile 'org.apache.httpcomponents:httpclient:4.5'
     compile 'com.squareup.okhttp:okhttp:2.5.0'
     compile 'com.google.code.gson:gson:2.3.1'

--- a/conf/capybara.yaml
+++ b/conf/capybara.yaml
@@ -6,11 +6,19 @@
 "database.id": "capybara"
 "database.password": "password"
 
-## slack設定
+# Slackの設定start
+# XMPP or Slack API でどちらかが必要
+
+## Slack設定(XMPPで接続)
 "slack.team": ""
 "slack.username": ""
 "slack.password": ""
 "slack.room": ""
+
+## Slack設定(Slack Real Time Messaging API)
+"slack.api.token": ""
+
+# Slack設定 end
 
 ## アイコン設定
 "icon.basic": ":grinning:"

--- a/src/main/java/Bootstrap.java
+++ b/src/main/java/Bootstrap.java
@@ -1,7 +1,9 @@
 
 import com.github.masahitojp.botan.Botan;
 import com.github.masahitojp.botan.adapter.SlackAdapter;
+import com.github.masahitojp.botan.adapter.SlackRTMAdapter;
 import com.github.masahitojp.botan.exception.BotanException;
+import com.google.common.base.Strings;
 import models.ConfigReader;
 import models.Database;
 import org.slf4j.Logger;
@@ -24,9 +26,12 @@ public class Bootstrap {
 
 		// bot env
 		final ConfigReader reader = ConfigReader.getInstance();
+		if(Strings.isNullOrEmpty(reader.getSlackApiToken())) {
+			throw new IllegalArgumentException("slack.api.token is null or empty");
+		}
 		final Botan botan = new Botan
 				.BotanBuilder()
-				.setAdapter(new SlackAdapter(reader.getSlackTeam(), reader.getSlackUserName(), reader.getSlackPassword(), reader.getSlackRoom()))
+				.setAdapter(new SlackRTMAdapter(reader.getSlackApiToken()))
 				.build();
 		this.botStoppable = Optional.of(botan);
 

--- a/src/main/java/models/ConfigReader.java
+++ b/src/main/java/models/ConfigReader.java
@@ -106,6 +106,10 @@ public class ConfigReader {
         return (String) yaml.get("slack.room");
     }
 
+    public String getSlackApiToken() {
+        return (String) yaml.get("slack.api.token");
+    }
+
     public String getGoogleMapApiKey() {
         return (String) yaml.get("google.map.api.key");
     }

--- a/src/main/resources/capybara.yaml
+++ b/src/main/resources/capybara.yaml
@@ -6,11 +6,19 @@
 "database.id": "capybara"
 "database.password": "password"
 
-## slack設定
+# Slackの設定start
+# XMPP or Slack API でどちらかが必要
+
+## Slack設定(XMPPで接続)
 "slack.team": ""
 "slack.username": ""
 "slack.password": ""
 "slack.room": ""
+
+## Slack設定(Slack Real Time Messaging API)
+"slack.api.token": ""
+
+# Slack設定 end
 
 ## アイコン設定
 "icon.basic": ":grinning:"

--- a/src/test/java/models/ConfigReaderTest.java
+++ b/src/test/java/models/ConfigReaderTest.java
@@ -100,6 +100,12 @@ public class ConfigReaderTest {
     }
 
     @Test
+    public void SlackAPITokenの取得テスト() {
+        final ConfigReader reader = ConfigReader.getInstance();
+        assertThat(reader.getSlackApiToken(), is(""));
+    }
+
+    @Test
     public void googleMapApiKeyの取得テスト() {
         final ConfigReader reader = ConfigReader.getInstance();
         assertThat(reader.getGoogleMapApiKey(), is(""));


### PR DESCRIPTION
Slack からBot Userを作成し、動作するところまで確認
https://api.slack.com/bot-users

slack.api.tokenに↑で取得したAPI TOKENを設定する必要があります。
attention: _ユーザ名、チャネルの設定_ はSlackから行います。channelから　invite, removeする必要があります。
attention: いままでのXMPPではなく、Slack APIを使う方に切り替えてあります。
