### PR TITLE
improved #117 version up of UnitTest module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,10 @@ dependencies {
     compile 'org.jsoup:jsoup:1.7.3'
     compile 'it.sauronsoftware.cron4j:cron4j:2.2.5'
 
-    testJMockit 'org.jmockit:jmockit:1.16'
+    testJMockit 'org.jmockit:jmockit:1.20'
     testCompile configurations.testJMockit.dependencies
     testCompile 'junit:junit:4.12'
+    testCompile "org.hamcrest:java-hamcrest:2.0.0.0"
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip

--- a/src/test/java/handlers/ShowMapHandlersTest.java
+++ b/src/test/java/handlers/ShowMapHandlersTest.java
@@ -14,13 +14,7 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(JMockit.class)
 public class ShowMapHandlersTest {
-    @Mocked({"getGoogleMapApiKey"
-            , "getGoogleMapLanguage"
-            , "getGoogleMapSensor"
-            , "getGoogleMapScale"
-            , "getGoogleMapZoom"
-            , "getGoogleMapSizeLength"
-            , "getGoogleMapSizeHeight"})
+
     @SuppressWarnings("unused")
     private ConfigReader reader;
 
@@ -30,8 +24,8 @@ public class ShowMapHandlersTest {
         final String expectString1 = "http://maps.googleapis.com/maps/api/staticmap?center=%E6%9D%B1%E4%BA%AC&size=500x500&scale=1&sensor=false&zoom=16&language=jp&markers=%E6%9D%B1%E4%BA%AC";
         final String inputAddress2 = "&&&";
         final String expectString2 = "http://maps.googleapis.com/maps/api/staticmap?center=%26%26%26&size=500x500&scale=1&sensor=false&zoom=16&language=jp&markers=%26%26%26";
-
-        new NonStrictExpectations() {
+        reader = ConfigReader.getInstance();
+        new NonStrictExpectations(ConfigReader.class) {
             {
                 reader.getGoogleMapApiKey();
                 result = "";


### PR DESCRIPTION
gradle + jmockit + hamcrest

http://jmockit.org/changes.html

> Removed the "value" attribute of @Mocked, which was deprecated in release 1.17. Existing tests using "@Mocked({"someMethod", "anotherMethod", ...})" should simply omit the attribute, or use partial mocking as applied with new Expectations(objToPartiallyMock) { ... }, or apply a MockUp<T> class. 

なので、UnitTest用のコードを書き変えてます。
