### PR TITLE
improve #117 version up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,17 +28,17 @@ configurations { testJMockit }
 
 dependencies {
     compile 'com.atilika.kuromoji:kuromoji-ipadic:0.9.0'
-    compile 'org.slf4j:slf4j-api:1.7.7'
-    compile 'org.slf4j:jul-to-slf4j:1.7.7'
+    compile 'org.slf4j:slf4j-api:1.7.12'
+    compile 'org.slf4j:jul-to-slf4j:1.7.12'
 
     compile 'ch.qos.logback:logback-classic:1.0.13'
     compile 'com.h2database:h2:1.3.168'
     compile 'org.jdbi:jdbi:2.43'
     compile 'com.google.guava:guava:18.0'
     compile 'org.yaml:snakeyaml:1.16'
-    compile 'com.github.masahitojp:nineteen:0.0.3'
-    compile 'com.github.masahitojp:botan-core:0.3.0.0'
-    compile 'com.github.masahitojp:botan-mapdb:0.2.0.2'
+    compile 'com.github.masahitojp:nineteen:0.0.4'
+    compile 'com.github.masahitojp:botan-core:0.3.1.0'
+    compile 'com.github.masahitojp:botan-mapdb:0.2.1.1'
     compile 'org.apache.httpcomponents:httpclient:4.5'
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'com.squareup.okhttp:okhttp:2.5.0'


### PR DESCRIPTION
- 川柳判定用ライブラリアップデート　かぴばらがヒットするように変更
- brainの書き込み周期変更
  etc
